### PR TITLE
addIceCandidate: dont throw on datachannel candidates

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -1333,6 +1333,9 @@ module.exports = function(window, edgeVersion) {
     var sections;
     if (!candidate || candidate.candidate === '') {
       for (var j = 0; j < this.transceivers.length; j++) {
+        if (this.transceivers[j].isDatachannel) {
+          continue;
+        }
         this.transceivers[j].iceTransport.addRemoteCandidate({});
         sections = SDPUtils.splitSections(this.remoteDescription.sdp);
         sections[j + 1] += 'a=end-of-candidates\r\n';
@@ -1359,6 +1362,9 @@ module.exports = function(window, edgeVersion) {
       }
       var transceiver = this.transceivers[sdpMLineIndex];
       if (transceiver) {
+        if (transceiver.isDatachannel) {
+          return Promise.resolve();
+        }
         var cand = Object.keys(candidate.candidate).length > 0 ?
             SDPUtils.parseCandidate(candidate.candidate) : {};
         // Ignore Chrome's invalid candidates since Edge does not like them.

--- a/test/rtcpeerconnection.js
+++ b/test/rtcpeerconnection.js
@@ -1488,7 +1488,7 @@ describe('Edge shim', () => {
       });
     });
 
-    it('rejects a data channel', (done) => {
+    describe('rejects a data channel', () => {
       const sdp = SDP_BOILERPLATE +
           'm=application 9 DTLS/SCTP 5000\r\n' +
           'c=IN IP4 0.0.0.0\r\n' +
@@ -1498,15 +1498,25 @@ describe('Edge shim', () => {
           'a=setup:actpass\r\n' +
           'a=mid:data\r\n' +
           'a=sctpmap:5000 webrtc-datachannel 1024\r\n';
-      pc.setRemoteDescription({type: 'offer', sdp: sdp})
-      .then(() => {
-        return pc.createAnswer();
-      })
-      .then((answer) => {
-        const sections = SDPUtils.splitSections(answer.sdp);
-        const rejected = SDPUtils.isRejected(sections[1]);
-        expect(rejected).to.equal(true);
-        done();
+      it('in setRemoteDescription', (done) => {
+        pc.setRemoteDescription({type: 'offer', sdp: sdp})
+        .then(() => {
+          return pc.createAnswer();
+        })
+        .then((answer) => {
+          const sections = SDPUtils.splitSections(answer.sdp);
+          const rejected = SDPUtils.isRejected(sections[1]);
+          expect(rejected).to.equal(true);
+          done();
+        });
+      });
+
+      it('and ignores candidates', () => {
+        return pc.setRemoteDescription({type: 'offer', sdp: sdp})
+        .then(() => {
+          return pc.addIceCandidate({sdpMid: 'data', candidate:
+              'candidate:702786350 1 udp 41819902 8.8.8.8 60769 typ host'});
+        });
       });
     });
 


### PR DESCRIPTION
makes addIceCandidate not throw on a data channel candidate.

Reported in https://github.com/webrtc/adapter/issues/596