### PR TITLE
filter stun:host:port?transport=udp even after r14393

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -65,7 +65,7 @@ function writeMediaSection(transceiver, caps, type, stream) {
 }
 
 // Edge does not like
-// 1) stun:
+// 1) stun: filtered after 14393 unless ?transport=udp is present
 // 2) turn: that does not have all of turn:host:port?transport=udp
 // 3) turn: with ipv6 addresses
 // 4) turn: occurring muliple times
@@ -92,7 +92,8 @@ function filterIceServers(iceServers, edgeVersion) {
           hasTurn = true;
           return true;
         }
-        return url.indexOf('stun:') === 0 && edgeVersion >= 14393;
+        return url.indexOf('stun:') === 0 && edgeVersion >= 14393 &&
+            url.indexOf('?transport=udp') === -1;
       });
 
       delete server.url;

--- a/test/rtcpeerconnection.js
+++ b/test/rtcpeerconnection.js
@@ -2725,7 +2725,7 @@ describe('Edge shim', () => {
       expect(config.iceServers).to.deep.equal([]);
     });
 
-    it('does not filter STUN after r14393', () => {
+    it('does not filter STUN without protocol after r14393', () => {
       pc = new RTCPeerConnection({
         iceServers: [{urls: 'stun:stun.l.google.com'}]
       });
@@ -2733,6 +2733,14 @@ describe('Edge shim', () => {
       expect(config.iceServers).to.deep.equal([
         {urls: 'stun:stun.l.google.com'}
       ]);
+    });
+
+    it('does filter STUN with protocol even after r14393', () => {
+      pc = new RTCPeerConnection({
+        iceServers: [{urls: 'stun:stun.l.google.com:19302?transport=udp'}]
+      });
+      const config = pc.getConfiguration();
+      expect(config.iceServers).to.deep.equal([]);
     });
 
     it('filters incomplete TURN urls', () => {


### PR DESCRIPTION
filters stun urls which are not filtered by the native layer.