### PR TITLE
setRemoteDescription: dont attempt to add ice candidates when transpo…

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -863,9 +863,8 @@ module.exports = function(window, edgeVersion) {
               usingBundle);
         }
 
-        if (cands.length) {
-          if (isComplete && (!usingBundle || sdpMLineIndex === 0)
-              && transceiver.iceTransport.state === 'new') {
+        if (cands.length && transceiver.iceTransport.state === 'new') {
+          if (isComplete && (!usingBundle || sdpMLineIndex === 0)) {
             transceiver.iceTransport.setRemoteCandidates(cands);
           } else {
             cands.forEach(function(candidate) {


### PR DESCRIPTION
…rt up

currently this code will try to add ice candidates in a subsequent offer that it has not seen before. As this will happen after addRemoteCandidate({}) it will fail. Prevent this from happening by only adding the candidates if the ice transport state is "new".