### PR TITLE
sdp: set a=setup properly in subsequent answers with role change

### DIFF
--- a/test/rtcpeerconnection.js
+++ b/test/rtcpeerconnection.js
@@ -2507,7 +2507,7 @@ describe('Edge shim', () => {
     });
   });
 
-  describe('remote reoffer', () => {
+  describe('remote reoffer with role change', () => {
     let pc1;
     let pc2;
     beforeEach(() => {
@@ -2546,6 +2546,35 @@ describe('Edge shim', () => {
         expect(audioEncodingParameters[0].ssrc).to.equal(2002);
         expect(videoEncodingParameters[0].ssrc).to.equal(4004);
         expect(videoEncodingParameters[0].rtx.ssrc).to.equal(4005);
+        done();
+      });
+    });
+
+    it('sets the right DTLS role in the answer', (done) => {
+      navigator.mediaDevices.getUserMedia({audio: true, video: true})
+      .then((stream) => {
+        pc1.addStream(stream);
+        return pc1.createOffer();
+      })
+      .then((offer) => pc1.setLocalDescription(offer))
+      .then(() => pc2.setRemoteDescription(pc1.localDescription))
+      .then(() => pc2.createAnswer())
+      .then((answer) => pc2.setLocalDescription(answer))
+      .then(() => pc1.setRemoteDescription(pc2.localDescription))
+      .then(() => {
+        return navigator.mediaDevices.getUserMedia({audio: true, video: true});
+      })
+      .then((stream) => {
+        pc2.addStream(stream);
+        return pc2.createOffer();
+      })
+      .then((offer) => pc2.setLocalDescription(offer))
+      .then(() => pc1.setRemoteDescription(pc2.localDescription))
+      .then(() => pc1.createAnswer())
+      .then((answer) => {
+        const sections = SDPUtils.splitSections(answer.sdp);
+        const setupLine = SDPUtils.matchPrefix(sections[1], 'a=setup:');
+        expect(setupLine[0]).to.equal('a=setup:passive');
         done();
       });
     });


### PR DESCRIPTION
this was sending a=setup:active unconditionally which it should not.