### PR TITLE
Fix sdpMLineIndex checking to allow 0

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -1443,7 +1443,7 @@ module.exports = function(window, edgeVersion) {
           break;
         }
       }
-    } else if (!(candidate.sdpMLineIndex != undefined || candidate.sdpMid != undefined)) {
+    } else if (!(candidate.sdpMLineIndex !== undefined || candidate.sdpMid)) {
       throw new TypeError('sdpMLineIndex or sdpMid required');
     } else if (!this.remoteDescription) {
       err = new Error('Can not add ICE candidate without ' +

--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -1443,7 +1443,7 @@ module.exports = function(window, edgeVersion) {
           break;
         }
       }
-    } else if (!(candidate.sdpMLineIndex || candidate.sdpMid)) {
+    } else if (!(candidate.sdpMLineIndex != undefined || candidate.sdpMid != undefined)) {
       throw new TypeError('sdpMLineIndex or sdpMid required');
     } else if (!this.remoteDescription) {
       err = new Error('Can not add ICE candidate without ' +


### PR DESCRIPTION
According to https://msdn.microsoft.com/en-us/library/mt806221(v=vs.85).aspx, "sdpMLineIndex property returns the index (starting at zero) of the media description in the SDP". 
As such, 0 is a valid value for sdpMLineIndex. The current code would throw an exception if sdpMLineIndex=0. 