### PR TITLE
remove support for transceiver.direction

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -24,9 +24,7 @@ function writeMediaSection(transceiver, caps, type, stream, dtlsRole) {
 
   sdp += 'a=mid:' + transceiver.mid + '\r\n';
 
-  if (transceiver.direction) {
-    sdp += 'a=' + transceiver.direction + '\r\n';
-  } else if (transceiver.rtpSender && transceiver.rtpReceiver) {
+  if (transceiver.rtpSender && transceiver.rtpReceiver) {
     sdp += 'a=sendrecv\r\n';
   } else if (transceiver.rtpSender) {
     sdp += 'a=sendonly\r\n';

--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -98,7 +98,6 @@ function filterIceServers(iceServers, edgeVersion) {
       server.urls = isString ? urls[0] : urls;
       return !!urls.length;
     }
-    return false;
   });
 }
 


### PR DESCRIPTION
this was old code from the sdp package which has not been used in a while.
And it was not covered by tests.