### PR TITLE
wrap RTCRtpSender

### DIFF
--- a/rtcrtpsender.js
+++ b/rtcrtpsender.js
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (c) 2017 Philipp Hancke. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+/* eslint-env node */
+'use strict';
+
+/* a wrapper around Edge's RTCRtpSender that does a lazy construct of
+ * of the native sender when all the required parameters (track and
+ * transport) are available.
+ */
+module.exports = function(window) {
+  var RTCRtpSender_ = window.RTCRtpSender;
+  var RTCRtpSender = function(trackOrKind, transport) {
+    this._sender = null;
+    this._track = null;
+    this._transport = null;
+
+    if (typeof trackOrKind === 'string') {
+      this.kind = trackOrKind;
+      this._transport = transport || null;
+    } else if (!transport) {
+      this._track = trackOrKind;
+      this.kind = trackOrKind.kind;
+    } else {
+      this._sender = new RTCRtpSender_(trackOrKind, transport);
+      this.kind = trackOrKind.kind;
+    }
+    this._isStopped = false;
+  };
+
+  // ORTC defines the DTMF sender a bit different.
+  // https://github.com/w3c/ortc/issues/714
+  Object.defineProperty(RTCRtpSender.prototype, 'dtmf', {
+    get: function() {
+      if (this._dtmf === undefined) {
+        if (this.kind === 'audio') {
+          if (!this._sender) {
+            var e = new Error('Can not access dtmf in this state');
+            e.name = 'InvalidStateError';
+            throw(e);
+          } else {
+            this._dtmf = new window.RTCDtmfSender(this._sender);
+          }
+        } else if (this.kind === 'video') {
+          this._dtmf = null;
+        }
+      }
+      return this._dtmf;
+    }
+  });
+
+  RTCRtpSender.getCapabilities = RTCRtpSender_.getCapabilities;
+
+  Object.defineProperty(RTCRtpSender.prototype, 'track', {
+    get: function() {
+      return this._sender ? this._sender.track : this._track;
+    }
+  });
+
+  Object.defineProperty(RTCRtpSender.prototype, 'transport', {
+    get: function() {
+      return this._sender ? this._sender.transport : this._transport;
+    }
+  });
+
+  RTCRtpSender.prototype.setTransport = function(transport) {
+    if (!this._sender && this._track) {
+      this._sender = new RTCRtpSender_(this._track, transport);
+    } else if (this._sender) {
+      this._sender.setTransport(transport);
+    } else {
+      this._transport = transport;
+    }
+  };
+
+  RTCRtpSender.prototype.replaceTrack = function(track) {
+    if (track && this.kind !== track.kind) {
+      return Promise.reject(new TypeError());
+    }
+    if (this._sender) {
+      this._sender.replaceTrack(track);
+    } else if (track && this._transport) {
+      this._sender = new RTCRtpSender_(track, this._transport);
+    } else {
+      this._track = track;
+    }
+    return Promise.resolve();
+  };
+
+  RTCRtpSender.prototype.setTrack = function(track) { // deprecated.
+    if (track && this.kind !== track.kind) {
+      return Promise.reject(new TypeError());
+    }
+    if (this._sender) {
+      this._sender.setTrack(track);
+    } else if (track && this._transport) {
+      this._sender = new RTCRtpSender_(track, this._transport);
+    } else {
+      this._track = track;
+    }
+    return Promise.resolve();
+  };
+
+  RTCRtpSender.prototype.send = function(parameters) {
+    if (this._sender) {
+      return this._sender.send(parameters);
+    }
+    var e = new Error('Can not call send in this state');
+    e.name = 'InvalidStateError';
+    return Promise.reject(e);
+  };
+
+  RTCRtpSender.prototype.stop = function() {
+    if (this._sender) {
+      this._sender.stop();
+    }
+  };
+
+  RTCRtpSender.prototype.getStats = function() {
+    if (this._sender) {
+      return this._sender.getStats();
+    }
+    var e = new Error('Can not call getStats in this state');
+    e.name = 'InvalidStateError';
+    return Promise.reject(e);
+  };
+  return RTCRtpSender;
+};

--- a/test/ortcmock.js
+++ b/test/ortcmock.js
@@ -221,10 +221,20 @@ module.exports = function(window) {
     this.track = track;
     this.transport = transport;
   };
-  RTCRtpSender.prototype.send = function() {};
+  RTCRtpSender.prototype.send = function() {
+    return Promise.resolve();
+  };
   RTCRtpSender.prototype.stop = function() {};
   RTCRtpSender.prototype.setTransport = function(transport) {
     this.transport = transport;
+  };
+  RTCRtpSender.prototype.setTrack = function(track) {
+    this.track = track;
+    return Promise.resolve();
+  };
+  RTCRtpSender.prototype.replaceTrack = function(track) {
+    this.track = track;
+    return Promise.resolve();
   };
 
   RTCRtpSender.getCapabilities = getCapabilities;
@@ -236,4 +246,13 @@ module.exports = function(window) {
     return Promise.resolve();
   };
   window.RTCRtpSender = RTCRtpSender;
+
+  // http://draft.ortc.org/#rtcdtmfsender*
+  const RTCDtmfSender = function(sender) {
+    this.sender = sender;
+    this.toneBuffer = '';
+    this.canInsertDTMF = true;
+  };
+  RTCDtmfSender.prototype.insertDTMF = function() {};
+  window.RTCDtmfSender = RTCDtmfSender;
 };

--- a/test/rtcpeerconnection.js
+++ b/test/rtcpeerconnection.js
@@ -3244,7 +3244,7 @@ describe('Edge shim', () => {
     it('throws an InvalidAccessError if the sender does not belong ' +
         'to the peerconnection', () => {
       const removeTrack = () => {
-        pc.removeTrack(new window.RTCRtpSender());
+        pc.removeTrack(new window.RTCRtpSender('audio'));
       };
       expect(removeTrack).to.throw(/not created by/)
           .that.has.property('name').that.equals('InvalidAccessError');
@@ -3254,7 +3254,7 @@ describe('Edge shim', () => {
         'closed already', () => {
       pc.close();
       const removeTrack = () => {
-        pc.removeTrack(new window.RTCRtpSender());
+        pc.removeTrack(new window.RTCRtpSender('audio'));
       };
       expect(removeTrack).to.throw()
           .that.has.property('name').that.equals('InvalidStateError');

--- a/test/rtcpeerconnection.js
+++ b/test/rtcpeerconnection.js
@@ -407,10 +407,12 @@ describe('Edge shim', () => {
       beforeEach(() => {
         sinon.spy(window.RTCIceTransport.prototype, 'start');
         sinon.spy(window.RTCDtlsTransport.prototype, 'start');
+        sinon.spy(window.RTCRtpSender.prototype, 'setTransport');
       });
       afterEach(() => {
         window.RTCIceTransport.prototype.start.restore();
         window.RTCDtlsTransport.prototype.start.restore();
+        window.RTCRtpSender.prototype.setTransport.restore();
       });
 
       const sdp = SDP_BOILERPLATE + MINIMAL_AUDIO_MLINE;
@@ -460,6 +462,26 @@ describe('Edge shim', () => {
               ])
             })
           );
+          done();
+        });
+      });
+
+      it('sets the RTPSender transport', (done) => {
+        pc.setRemoteDescription({type: 'offer', sdp: sdp})
+        .then(() => {
+          return navigator.mediaDevices.getUserMedia({audio: true});
+        })
+        .then((stream) => {
+          pc.addTrack(stream.getAudioTracks()[0], stream);
+          return pc.createAnswer();
+        })
+        .then((answer) => {
+          return pc.setLocalDescription(answer);
+        })
+        .then(() => {
+          const sender = pc.getSenders()[0];
+          expect(sender.setTransport).to.have.been.calledOnce();
+          expect(sender.transport).not.to.equal(null);
           done();
         });
       });
@@ -740,6 +762,8 @@ describe('Edge shim', () => {
           // and the second one needs to be disposed.
           return pc.setRemoteDescription({type: 'offer', sdp: sdp});
         })
+        .then(() => pc.createAnswer())
+        .then((answer) => pc.setLocalDescription(answer))
         .then(() => {
           const senders = pc.getSenders();
           // the second ice transport should have been disposed.
@@ -1107,12 +1131,9 @@ describe('Edge shim', () => {
       });
     });
 
-    describe('with type=answer', () => {
+    describe('with an answer', () => {
       beforeEach(() => {
         sinon.spy(window.RTCIceTransport.prototype, 'setRemoteCandidates');
-        return pc.createOffer({offerToReceiveAudio: true,
-            offerToReceiveVideo: true})
-          .then(offer => pc.setLocalDescription(offer));
       });
       afterEach(() => {
         window.RTCIceTransport.prototype.setRemoteCandidates.restore();
@@ -1139,7 +1160,9 @@ describe('Edge shim', () => {
             'a=ssrc:1002 cname:some\r\n' +
             'a=candidate:702786350 1 udp 41819902 8.8.8.8 60769 typ host\r\n' +
             'a=end-of-candidates\r\n';
-        pc.setRemoteDescription({type: 'answer', sdp})
+        pc.createOffer({offerToReceiveAudio: true, offerToReceiveVideo: true})
+        .then(offer => pc.setLocalDescription(offer))
+        .then(() => pc.setRemoteDescription({type: 'answer', sdp}))
         .then(() => {
           const receiver = pc.getReceivers()[0];
           const iceTransport = receiver.transport.transport;
@@ -3498,13 +3521,17 @@ describe('Edge shim', () => {
 
   describe('getStats', () => {
     let pc;
+    const sdp = SDP_BOILERPLATE + MINIMAL_AUDIO_MLINE;
     beforeEach((done) => {
       pc = new RTCPeerConnection();
       navigator.mediaDevices.getUserMedia({audio: true})
       .then((stream) => {
         pc.addTrack(stream.getAudioTracks()[0], stream);
-        done();
-      });
+        return pc.setRemoteDescription({type: 'offer', sdp});
+      })
+      .then(() => pc.createAnswer())
+      .then(answer => pc.setLocalDescription(answer))
+      .then(() => done());
     });
     afterEach(() => {
       pc.close();
@@ -3541,19 +3568,16 @@ describe('Edge shim', () => {
           expect(sender.getStats).to.have.been.calledOnce();
         });
       });
+
       it('calls getStats on the receiver', () => {
-        const sdp = SDP_BOILERPLATE + MINIMAL_AUDIO_MLINE;
-        let receiver;
-        return pc.setRemoteDescription({type: 'offer', sdp})
-        .then(() => {
-          receiver = pc.getReceivers()[0];
-          sinon.spy(receiver, 'getStats');
-          return pc.getStats(receiver.track);
-        })
+        let receiver = pc.getReceivers()[0];
+        sinon.spy(receiver, 'getStats');
+        return pc.getStats(receiver.track)
         .then(() => {
           expect(receiver.getStats).to.have.been.calledOnce();
         });
       });
+
       it('throws an InvalidAccessError if the track is not assocіated', () => {
         const getStats = () => {
           pc.getStats(new window.MediaStreamTrack());
@@ -3724,6 +3748,25 @@ describe('Edge shim', () => {
 
       expect(stub).to.have.been.calledOnce();
       expect(pc.iceConnectionState).to.equal('disconnected');
+    });
+  });
+
+  describe('addTrack', () => {
+    let pc;
+    let audioTrack;
+    beforeEach((done) => {
+      pc = new RTCPeerConnection();
+      navigator.mediaDevices.getUserMedia({audio: true})
+      .then((stream) => {
+        audioTrack = stream.getAudioTracks()[0];
+        done();
+      });
+    });
+
+    it('returns a sender whose transport is not set', () => {
+      const sender = pc.addTrack(audioTrack);
+      expect(sender).to.be.an.instanceOf(window.RTCRtpSender);
+      expect(sender.transport).to.equal(null);
     });
   });
 

--- a/test/rtcrtpsender.js
+++ b/test/rtcrtpsender.js
@@ -1,0 +1,321 @@
+/*
+ *  Copyright (c) 2017 Philipp Hancke. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+/* eslint-env node */
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+chai.use(require('dirty-chai'));
+chai.use(require('sinon-chai'));
+
+const mockORTC = require('./ortcmock');
+const mockGetUserMedia = require('./gummock');
+
+const shimSenderWithTrackOrKind = require('../rtcrtpsender');
+
+// this detects that we are not running in a browser.
+const mockWindow = typeof window === 'undefined';
+
+describe('RTCRtpSender wrapper', () => {
+  const kind = 'audio';
+  let nativeConstructorStub;
+  let sender;
+  let track;
+  let transport;
+
+  beforeEach(() => {
+    if (mockWindow) {
+      global.window = {};
+      mockORTC(window);
+      mockGetUserMedia(window);
+
+      track = new window.MediaStreamTrack();
+      track.kind = kind;
+
+      transport = new window.RTCDtlsTransport();
+    }
+  });
+
+  describe('allows constructing RTCRtpSender with', () => {
+    beforeEach(() => {
+      nativeConstructorStub = sinon.stub(window, 'RTCRtpSender');
+      window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+    });
+    afterEach(() => {
+      nativeConstructorStub.restore();
+    });
+
+    describe('only a kind', () => {
+      beforeEach(() => {
+        sender = new window.RTCRtpSender(kind);
+      });
+
+      it('sets sender.kind', () => {
+        expect(sender.kind).to.equal(kind);
+      });
+
+      it('does not call the native constructor', () => {
+        expect(nativeConstructorStub).not.to.have.been.called();
+      });
+    });
+
+    describe('only a track', () => {
+      beforeEach(() => {
+        sender = new window.RTCRtpSender(track);
+      });
+
+      it('sets sender.kind', () => {
+        expect(sender.kind).to.equal(kind);
+      });
+
+      it('does not call the native constructor', () => {
+        expect(nativeConstructorStub).not.to.have.been.called();
+      });
+    });
+
+    describe('a track and a transport', () => {
+      beforeEach(() => {
+        sender = new window.RTCRtpSender(track, transport);
+      });
+
+      it('sets sender.kind', () => {
+        expect(sender.kind).to.equal(kind);
+      });
+
+      it('calls the native constructor', () => {
+        expect(nativeConstructorStub).to.have.been.called();
+      });
+    });
+  });
+
+  describe('when constructed with', () => {
+    beforeEach(() => {
+      nativeConstructorStub = sinon.stub(window, 'RTCRtpSender');
+      window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+    });
+
+    it('track it calls the constructor after setTransport', () => {
+      sender = new window.RTCRtpSender(track);
+      sender.setTransport(transport);
+
+      expect(nativeConstructorStub).to.have.been.called();
+    });
+
+    ['setTrack', 'replaceTrack'].forEach((setOrReplaceTrack) => {
+      it('kind it calls the constructor after ' + setOrReplaceTrack +
+         ' and setTransport', () => {
+        sender = new window.RTCRtpSender(kind);
+        sender[setOrReplaceTrack](track);
+        sender.setTransport(transport);
+
+        expect(nativeConstructorStub).to.have.been.called();
+      });
+
+      it('kind and transport it calls the constructor after ' +
+         setOrReplaceTrack, () => {
+        sender = new window.RTCRtpSender(kind, transport);
+        sender[setOrReplaceTrack](track);
+
+        expect(nativeConstructorStub).to.have.been.called();
+      });
+    });
+  });
+
+  describe('track attribute', () => {
+    beforeEach(() => {
+      window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+    });
+
+    it('returns the track when constructed with track', () => {
+      sender = new window.RTCRtpSender(track);
+      expect(sender.track).to.equal(track);
+    });
+
+    it('returns the track when constructed with track and transport', () => {
+      sender = new window.RTCRtpSender(track, transport);
+      expect(sender.track).to.equal(track);
+    });
+
+    it('returns null when constructed with kind', () => {
+      sender = new window.RTCRtpSender(kind);
+      expect(sender.track).to.equal(null);
+    });
+  });
+
+  describe('transport attribute', () => {
+    beforeEach(() => {
+      window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+    });
+
+    it('returns null when constructed with kind', () => {
+      sender = new window.RTCRtpSender(kind);
+      expect(sender.transport).to.equal(null);
+    });
+
+    it('returns null when constructed with track', () => {
+      sender = new window.RTCRtpSender(track);
+      expect(sender.transport).to.equal(null);
+    });
+
+    it('returns the transport when constructed with kind and transport', () => {
+      sender = new window.RTCRtpSender(kind, transport);
+      expect(sender.transport).to.equal(transport);
+    });
+
+    it('returns the transport when constructed with track ' +
+        'and transport', () => {
+      sender = new window.RTCRtpSender(track, transport);
+      expect(sender.transport).to.equal(transport);
+    });
+  });
+
+  describe('setTransport', () => {
+    it('calls the native constructor when construced with track', () => {
+      nativeConstructorStub = sinon.stub(window, 'RTCRtpSender');
+      window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+
+      sender = new window.RTCRtpSender(track);
+      sender.setTransport(transport);
+      expect(nativeConstructorStub).to.have.been.called();
+    });
+
+    it('calls the native setTransport', () => {
+      window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+
+      sender = new window.RTCRtpSender(track, transport);
+      const nativeSetTransport = sinon.stub(sender._sender, 'setTransport');
+
+      const transport2 = new window.RTCDtlsTransport();
+      sender.setTransport(transport2);
+      expect(nativeSetTransport).to.have.been.called();
+    });
+
+    it('sets the transport when constructed with only kind', () => {
+      window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+
+      sender = new window.RTCRtpSender(kind);
+      sender.setTransport(transport);
+      expect(sender.transport).to.equal(transport);
+    });
+  });
+
+  ['setTrack', 'replaceTrack'].forEach((setOrReplaceTrack) => {
+    describe(setOrReplaceTrack, () => {
+      beforeEach(() => {
+        window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+        sender = new window.RTCRtpSender(track, transport);
+      });
+
+      it('rejects when the new tracks kind does not match', (done) => {
+        const newTrack = new window.MediaStreamTrack();
+        newTrack.kind = 'somethingElse';
+        sender[setOrReplaceTrack](newTrack)
+          .catch((err) => {
+            done();
+          });
+      });
+
+      it('calls the native ' + setOrReplaceTrack, () => {
+        const nativeStub = sinon.stub(sender._sender, setOrReplaceTrack);
+        sender[setOrReplaceTrack](null);
+        expect(nativeStub).to.have.been.called();
+      });
+    });
+  });
+
+  describe('send', () => {
+    beforeEach(() => {
+      window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+    });
+
+    it('calls the native send method if a native sender exists', () => {
+      sender = new window.RTCRtpSender(track, transport);
+      const nativeSend = sinon.stub(sender._sender, 'send');
+
+      sender.send('mock parameters');
+      expect(nativeSend).to.have.been.called();
+    });
+
+    it('rejects with InvalidTypeError when the native sender ' +
+       'does not exist', (done) => {
+      sender = new window.RTCRtpSender(kind, transport);
+      sender.send('mock parameters')
+        .catch((err) => {
+          done();
+        });
+    });
+  });
+  describe('stop', () => {
+    beforeEach(() => {
+      window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+    });
+
+    it('stops the native sender if it exists', () => {
+      sender = new window.RTCRtpSender(track, transport);
+      const nativeStop = sinon.stub(sender._sender, 'stop');
+
+      sender.stop();
+      expect(nativeStop).to.have.been.called();
+    });
+  });
+
+  describe('dtmf', () => {
+    beforeEach(() => {
+      window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+    });
+
+    it('throws InvalidStateError when accessed without a native sender', () => {
+      sender = new window.RTCRtpSender(kind);
+      const accessor = () => {
+        return sender.dtmf;
+      };
+      expect(accessor).to.throw()
+          .that.has.property('name').that.equals('InvalidStateError');
+    });
+
+    it('exists on audio senders', () => {
+      sender = new window.RTCRtpSender(track, transport);
+      const dtmf = sender.dtmf;
+      expect(dtmf).not.to.equal(null);
+      expect(dtmf).to.have.property('insertDTMF');
+    });
+
+    it('does not exist on video senders', () => {
+      sender = new window.RTCRtpSender('video');
+      expect(sender.dtmf).to.equal(null);
+    });
+  });
+
+  describe('getStats', () => {
+    beforeEach(() => {
+      window.RTCRtpSender = shimSenderWithTrackOrKind(window);
+    });
+
+    it('calls the native senders getStats', (done) => {
+      sender = new window.RTCRtpSender(track, transport);
+      const nativeGetStats = sinon.stub(sender._sender, 'getStats')
+          .returns(Promise.resolve());
+
+      sender.getStats()
+      .then(() => {
+        expect(nativeGetStats).to.have.been.called();
+        done();
+      });
+    });
+
+    it('rejects with InvalidStateError when called without a ' +
+        'native sender', (done) => {
+      sender = new window.RTCRtpSender(kind);
+      sender.getStats()
+        .catch((err) => {
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
adds a wrapper which does a lazy construction of Edge's native
RTCRtpSender. This will allow creating a sender without a track
or a transport.