### PR TITLE
test: add tests for on* property on prototype

### DIFF
--- a/test/rtcpeerconnection.js
+++ b/test/rtcpeerconnection.js
@@ -151,6 +151,17 @@ describe('Edge shim', () => {
     });
   });
 
+  describe('prototype', () => {
+    ['icecandidate', 'addstream', 'removestream', 'track',
+        'signalingstatechange', 'iceconnectionstatechange',
+        'icegatheringstatechange', 'negotiationneeded'].forEach((name) => {
+          it('has on' + name + ' handler', () => {
+            expect(RTCPeerConnection.prototype)
+                .to.have.ownPropertyDescriptor('on' + name);
+          });
+        });
+  });
+
   describe('setLocalDescription', () => {
     let pc;
     beforeEach(() => {


### PR DESCRIPTION
test for ondatachannel is omitted on purpose.