### PR TITLE
fix legacy createOffer regression

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -1287,9 +1287,8 @@ module.exports = function(window, edgeVersion) {
       return new Promise(function(resolve, reject) {
         var e = new Error('Can not call createOffer after close');
         e.name = 'InvalidStateError';
-        var eb = typeof args[0] === 'function' ? args[1] : args[2];
-        if (eb && typeof eb === 'function') {
-          eb.apply(null, [e]);
+        if (args.length > 1 && typeof args[1] === 'function') {
+          args[1].apply(null, [e]);
           return resolve();
         }
         reject(e);

--- a/test/rtcpeerconnection.js
+++ b/test/rtcpeerconnection.js
@@ -1301,10 +1301,10 @@ describe('Edge shim', () => {
     it('throws an InvalidStateError when called after close ' +
         '(callback)', (done) => {
       pc.close();
-      pc.createOffer({offerToReceiveAudio: true}, undefined, (e) => {
+      pc.createOffer(undefined, (e) => {
         expect(e.name).to.equal('InvalidStateError');
         done();
-      });
+      }, {offerToReceiveAudio: true});
     });
 
     describe('throws a TypeError when called with legacy constraints', () => {


### PR DESCRIPTION
the offerOptions is the optional third argument and the error callback always second