### PR TITLE
removeTrack: throw when called on a closed connection

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -399,17 +399,17 @@ module.exports = function(window, edgeVersion) {
   };
 
   RTCPeerConnection.prototype.addTrack = function(track, stream) {
+    if (this._isClosed) {
+      throw makeError('InvalidStateError',
+          'Attempted to call addTrack on a closed peerconnection.');
+    }
+
     var alreadyExists = this.transceivers.find(function(s) {
       return s.track === track;
     });
 
     if (alreadyExists) {
       throw makeError('InvalidAccessError', 'Track already exists.');
-    }
-
-    if (this.signalingState === 'closed') {
-      throw makeError('InvalidStateError',
-          'Attempted to call addTrack on a closed peerconnection.');
     }
 
     var transceiver;
@@ -460,6 +460,11 @@ module.exports = function(window, edgeVersion) {
   };
 
   RTCPeerConnection.prototype.removeTrack = function(sender) {
+    if (this._isClosed) {
+      throw makeError('InvalidStateError',
+          'Attempted to call removeTrack on a closed peerconnection.');
+    }
+
     if (!(sender instanceof window.RTCRtpSender)) {
       throw new TypeError('Argument 1 of RTCPeerConnection.removeTrack ' +
           'does not implement interface RTCRtpSender.');

--- a/test/rtcpeerconnection.js
+++ b/test/rtcpeerconnection.js
@@ -3151,24 +3151,36 @@ describe('Edge shim', () => {
       pc = new RTCPeerConnection();
     });
     afterEach(() => {
-      pc.close();
+      if (pc.signalingState !== 'closed') {
+        pc.close();
+      }
     });
 
     it('throws a TypeError if the argument is not an RTCRtpSender', () => {
-      const constructor = () => {
+      const removeTrack = () => {
         pc.removeTrack('something');
       };
-      expect(constructor).to.throw(/does not implement/)
+      expect(removeTrack).to.throw(/does not implement/)
           .that.has.property('name').that.equals('TypeError');
     });
 
     it('throws an InvalidAccessError if the sender does not belong ' +
         'to the peerconnection', () => {
-      const constructor = () => {
+      const removeTrack = () => {
         pc.removeTrack(new window.RTCRtpSender());
       };
-      expect(constructor).to.throw(/not created by/)
+      expect(removeTrack).to.throw(/not created by/)
           .that.has.property('name').that.equals('InvalidAccessError');
+    });
+
+    it('throws an InvalidStateError if the peerconnection has been ' +
+        'closed already', () => {
+      pc.close();
+      const removeTrack = () => {
+        pc.removeTrack(new window.RTCRtpSender());
+      };
+      expect(removeTrack).to.throw()
+          .that.has.property('name').that.equals('InvalidStateError');
     });
 
     it('makes the m-line recvonly', () => {


### PR DESCRIPTION
fixes an upstream test failure in adapter