### PR TITLE
createOffer: retain mid

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -1326,7 +1326,7 @@ module.exports = function(window, edgeVersion) {
       // dtls transport, potentially rtpsender and rtpreceiver.
       var track = transceiver.track;
       var kind = transceiver.kind;
-      var mid = SDPUtils.generateIdentifier();
+      var mid = transceiver.mid || SDPUtils.generateIdentifier();
       transceiver.mid = mid;
 
       if (!transceiver.iceGatherer) {

--- a/test/rtcpeerconnection.js
+++ b/test/rtcpeerconnection.js
@@ -1689,6 +1689,20 @@ describe('Edge shim', () => {
         });
       });
     });
+
+    describe('when called after SRD+createAnswer reversing the roles', () => {
+      const sdp = SDP_BOILERPLATE + MINIMAL_AUDIO_MLINE;
+      it('retains the MID attribute', () => {
+        return pc.setRemoteDescription({type: 'offer', sdp})
+        .then(() => pc.createAnswer())
+        .then((answer) => pc.setLocalDescription(answer))
+        .then(() => pc.createOffer())
+        .then((offer) => {
+          const sections = SDPUtils.splitSections(offer.sdp);
+          expect(SDPUtils.getMid(sections[1])).to.equal('audio1');
+        });
+      });
+    });
   });
 
   describe('createAnswer', () => {


### PR DESCRIPTION
retains the MID instead of generating a new one.
Fixes https://github.com/webrtc/adapter/issues/745
and https://bugs.chromium.org/p/chromium/issues/detail?id=797766