### PR TITLE
rtcpeerconnection: fix addIceCandidate regression

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -1669,7 +1669,9 @@ module.exports = function(window, edgeVersion) {
           sections[sdpMLineIndex] += 'a=' +
               (cand.type ? candidateString : 'end-of-candidates')
               + '\r\n';
-          pc.remoteDescription.sdp = sections.join('');
+          pc.remoteDescription.sdp =
+              SDPUtils.getDescription(pc.remoteDescription.sdp) +
+              sections.join('');
         } else {
           return reject(makeError('OperationError',
               'Can not add ICE candidate'));

--- a/test/rtcpeerconnection.js
+++ b/test/rtcpeerconnection.js
@@ -2650,7 +2650,8 @@ describe('Edge shim', () => {
     it('adds the candidate to the remote description', (done) => {
       pc.addIceCandidate({sdpMid, candidate: candidateString})
       .then(() => {
-        expect(SDPUtils.matchPrefix(pc.remoteDescription.sdp,
+        const sections = SDPUtils.getMediaSections(pc.remoteDescription.sdp);
+        expect(SDPUtils.matchPrefix(sections[0],
             'a=candidate:')).to.have.length(1);
         done();
       });


### PR DESCRIPTION
under certain circumstances addIceCandidate would consume the remoteDescription.
Regression from #85

Made addIceCandidate test more specific to catch this.

essentially what would happen is that addIceCandidate remove the session part of the remotedescription. Then the first m-line would become the session part and be removed in the next addIceCandidate. And so forth...