### PR TITLE
getStats: wrap getStats method of each object

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -10,6 +10,16 @@
 
 var SDPUtils = require('sdp');
 
+function fixStatsType(stat) {
+  return {
+    inboundrtp: 'inbound-rtp',
+    outboundrtp: 'outbound-rtp',
+    candidatepair: 'candidate-pair',
+    localcandidate: 'local-candidate',
+    remotecandidate: 'remote-candidate'
+  }[stat.type] || stat.type;
+}
+
 function writeMediaSection(transceiver, caps, type, stream, dtlsRole) {
   var sdp = SDPUtils.writeRtpDescription(transceiver.kind, caps);
 
@@ -1691,29 +1701,37 @@ module.exports = function(window, edgeVersion) {
             }
           });
     });
-    var fixStatsType = function(stat) {
-      return {
-        inboundrtp: 'inbound-rtp',
-        outboundrtp: 'outbound-rtp',
-        candidatepair: 'candidate-pair',
-        localcandidate: 'local-candidate',
-        remotecandidate: 'remote-candidate'
-      }[stat.type] || stat.type;
-    };
-    return new Promise(function(resolve) {
-      // shim getStats with maplike support
+    return Promise.all(promises).then(function(allStats) {
       var results = new Map();
-      Promise.all(promises).then(function(res) {
-        res.forEach(function(result) {
-          Object.keys(result).forEach(function(id) {
-            result[id].type = fixStatsType(result[id]);
-            results.set(id, result[id]);
-          });
+      allStats.forEach(function(stats) {
+        stats.forEach(function(stat) {
+          results.set(stat.id, stat);
         });
-        resolve(results);
       });
+      return results;
     });
   };
+
+  // fix low-level stat names and return Map instead of object.
+  var ortcObjects = ['RTCRtpSender', 'RTCRtpReceiver', 'RTCIceGatherer',
+    'RTCIceTransport', 'RTCDtlsTransport'];
+  ortcObjects.forEach(function(ortcObjectName) {
+    var obj = window[ortcObjectName];
+    if (obj && obj.prototype && obj.prototype.getStats) {
+      var nativeGetstats = obj.prototype.getStats;
+      obj.prototype.getStats = function() {
+        return nativeGetstats.apply(this)
+        .then(function(nativeStats) {
+          var mapStats = new Map();
+          Object.keys(nativeStats).forEach(function(id) {
+            nativeStats[id].type = fixStatsType(nativeStats[id]);
+            mapStats.set(id, nativeStats[id]);
+          });
+          return mapStats;
+        });
+      };
+    }
+  });
 
   // legacy callback shims. Should be moved to adapter.js some days.
   var methods = ['createOffer', 'createAnswer'];

--- a/test/ortcmock.js
+++ b/test/ortcmock.js
@@ -229,7 +229,7 @@ module.exports = function(window) {
 
   RTCRtpSender.getCapabilities = getCapabilities;
   RTCRtpSender.prototype.getStats = function() {
-    return Promise.resolve({});
+    return Promise.resolve({123: {type: 'outboundrtp', id: 123}});
   };
   RTCRtpSender.prototype.replaceTrack = function(withTrack) {
     this.track = withTrack;

--- a/test/rtcpeerconnection.js
+++ b/test/rtcpeerconnection.js
@@ -3522,6 +3522,15 @@ describe('Edge shim', () => {
         done();
       });
     });
+
+    it('hyphenates stats', () => {
+      return pc.getStats()
+      .then(stats => {
+        let hasOutbound = false;
+        stats.forEach(stat => hasOutbound |= (stat.type === 'outbound-rtp'));
+        expect(hasOutbound).to.equal(1); // |= changes to 1.
+      });
+    });
   });
 
   describe('RTCIceCandidate contains a port property in', () => {


### PR DESCRIPTION
wraps the getStats methods of RTCIceGatherer, RTCIceTransport,
RTCDtlsTransport, RTCRtpSender and RTCRtpReceiver so they return
map-like and hyphenated stats.