### PR TITLE
h264: make codec name comparison case-independent

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -1392,7 +1392,7 @@ module.exports = function(window, edgeVersion) {
       localCapabilities.codecs.forEach(function(codec) {
         // work around https://bugs.chromium.org/p/webrtc/issues/detail?id=6552
         // by adding level-asymmetry-allowed=1
-        if (codec.name === 'H264' &&
+        if (codec.name.toLowerCase() === 'h264' &&
             codec.parameters['level-asymmetry-allowed'] === undefined) {
           codec.parameters['level-asymmetry-allowed'] = '1';
         }

--- a/test/ortcmock.js
+++ b/test/ortcmock.js
@@ -161,7 +161,7 @@ module.exports = function(window) {
           {type: 'nack', parameter: 'pli'}
       ]
     };
-    var rtx = {
+    var vp8rtx = {
       name: 'rtx',
       kind: 'video',
       clockRate: 90000,
@@ -169,16 +169,28 @@ module.exports = function(window) {
       numChannels: 1,
       parameters: {apt: 100}
     };
+    var h264 = {
+      name: 'h264',
+      kind: 'video',
+      clockRate: 90000,
+      preferredPayloadType: 100,
+      numChannels: 1,
+      rtcpFeedback: [
+          {type: 'nack', parameter: ''},
+          {type: 'nack', parameter: 'pli'}
+      ],
+      parameters: []
+    };
     var codecs;
     switch (kind) {
       case 'audio':
         codecs = [opus];
         break;
       case 'video':
-        codecs = [vp8, rtx];
+        codecs = [vp8, vp8rtx, h264];
         break;
       default:
-        codecs = [opus, vp8, rtx];
+        codecs = [opus, vp8, vp8rtx, h264];
         break;
     }
     var headerExtensions;


### PR DESCRIPTION
also extends test mock to add h264 codec
(note that edge always had uppercase)