### PR TITLE
bufferedCandidateEvents accessed when null

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -542,7 +542,7 @@ module.exports = function(window, edgeVersion) {
       return;
     }
     var bufferedCandidateEvents =
-      this.transceivers[sdpMLineIndex].bufferedCandidateEvents;
+      this.transceivers[sdpMLineIndex].bufferedCandidateEvents || [];
     this.transceivers[sdpMLineIndex].bufferedCandidateEvents = null;
     iceGatherer.removeEventListener('localcandidate',
       this.transceivers[sdpMLineIndex].bufferCandidates);


### PR DESCRIPTION
I did not try to trace the cause of this situation, I simply modified the file to prevent the possible error condition.
Line 628 was called with bufferedCandidateEvents set to null.