### PR TITLE
Remote DTLS role fix

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -878,7 +878,8 @@ module.exports = function(window, edgeVersion) {
           sessionpart);
         remoteDtlsParameters.role = 'client';
         if (isIceLite) {
-          remoteDtlsParameters.role = 'server';}
+          remoteDtlsParameters.role = 'server';
+        }
       }
       recvEncodingParameters =
           SDPUtils.parseRtpEncodingParameters(mediaSection);

--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -764,7 +764,8 @@ module.exports = function(window, edgeVersion) {
 
     var sections = SDPUtils.splitSections(description.sdp);
     var sessionpart = sections.shift();
-
+    var isIceLite = SDPUtils.matchPrefix(sessionpart,
+      'a=ice-lite').length > 0;
     var usesMux = true;
     sections.forEach(function(mediaSection, sdpMLineIndex) {
       var kind = SDPUtils.getKind(mediaSection);
@@ -876,6 +877,8 @@ module.exports = function(window, edgeVersion) {
         remoteDtlsParameters = SDPUtils.getDtlsParameters(mediaSection,
           sessionpart);
         remoteDtlsParameters.role = 'client';
+        if (isIceLite) {
+          remoteDtlsParameters.role = 'server';}
       }
       recvEncodingParameters =
           SDPUtils.parseRtpEncodingParameters(mediaSection);


### PR DESCRIPTION
Applied the condition found in setLocalDescription function that sets the DTLS transport role to 'server' if  isIceLite variable is true, to the setRemoteDescription function. 

Fixes error:
ORTC18615: ORTC RTCDtlsTransport: DTLS handshake failed. hr=c004e00f.

Seems like this outstanding pull request may also be related: 
https://github.com/otalk/rtcpeerconnection-shim/pull/184